### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Swift Date Tools 
 [![Build Status](https://travis-ci.org/codewise/ios-date-tools.svg?branch=master)](https://travis-ci.org/codewise/ios-date-tools)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/SwiftDateTools/badge.png)](http://cocoapods.org/?q=swiftdatetools)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/SwiftDateTools/badge.png)](http://cocoapods.org/?q=swiftdatetools)
 
 Project is a swift version of [DateTools](https://github.com/MatthewYork/DateTools) library created by Matthew York.
 
 ## Installation
 
-**Cocoapods**
+**CocoaPods**
 
 <code>pod 'SwiftDateTools'</code>
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
